### PR TITLE
fix: damage triggers not applying if damage is fully blocked by absorption

### DIFF
--- a/common/src/main/java/robotgiggle/hierophantics/mixin/PlayerEntityMixin.java
+++ b/common/src/main/java/robotgiggle/hierophantics/mixin/PlayerEntityMixin.java
@@ -36,7 +36,7 @@ public class PlayerEntityMixin {
         }
 	}
     
-    @Inject(method = "applyDamage", at = @At("TAIL"))
+    @Inject(method = "applyDamage", at = @At("RETURN"))
 	private void fireTriggersAfterDamage(DamageSource source, float amount, CallbackInfo ci) {
 		if (!HierophanticsConfig.getServer().getEarlyDamageTriggers()) {
             hierophantics$fireDamageTriggers(source, amount);


### PR DESCRIPTION
Previously, the damage triggers only fire if damage is not entirely blocked by absorption. This runs contrary to player expectations (since the health bar still visually drops, invincibility frames are granted, and all the other usual damage things happen). This was due to a mixin injecting `@At("TAIL")`, which [doesn't necessarily correspond to the bottom of the applyDamage function](https://github.com/SpongePowered/Mixin/wiki/Injection-Point-Reference#tail). Thus, post mixin injection, the code looks like this (obtained via `-Dmixin.debug.export=true`):
<img width="1018" height="577" alt="image" src="https://github.com/user-attachments/assets/3407d2bb-0c78-40d5-9d63-45f5a59ac04d" />
`fireTriggersAfterDamage` in `PlayerEntityMixin` (common) is placed inside the if statement condition.

This pull request changes the injection point to `@At("RETURN")`, which injects at all return points. Post mixin injection view with the PR changes:
<img width="1009" height="663" alt="image" src="https://github.com/user-attachments/assets/734c649d-c816-46d7-8919-ae5deccd6e16" />

`fireTriggersAfterDamage` doesn't actually fire the damage trigger if the player was invulnerable to the damage source, so the first inject is fine to leave in. The other two injection points are correct.
`fireTriggersAfterDamage` also fires the health decrease trigger, but only if the player is dead. No damage is dealt if the player is invulnerable, so those triggers will (correctly) not fire either.